### PR TITLE
Added plugin for custom load balancing

### DIFF
--- a/BroControl/config.py
+++ b/BroControl/config.py
@@ -402,7 +402,7 @@ class Configuration:
             if not node.lb_method:
                 raise ConfigurationError("no load balancing method given for node '%s'" % node.name)
 
-            if node.lb_method not in ("pf_ring", "myricom", "interfaces"):
+            if node.lb_method not in ("pf_ring", "myricom", "custom", "interfaces"):
                 raise ConfigurationError("unknown load balancing method '%s' given for node '%s'" % (node.lb_method, node.name))
 
             if node.lb_method == "interfaces":

--- a/BroControl/node.py
+++ b/BroControl/node.py
@@ -43,8 +43,8 @@ class Node:
 
         ``lb_method`` (string)
             The load balancing method to distribute packets to all of the
-            processes (must be one of: ``pf_ring``, ``myricom``, or
-            ``interfaces``).
+            processes (must be one of: ``pf_ring``, ``myricom``, ``custom``
+            or ``interfaces``).
 
         ``lb_interfaces`` (string)
             If the load balancing method is ``interfaces``, then this is

--- a/BroControl/plugins/lb_custom.py
+++ b/BroControl/plugins/lb_custom.py
@@ -1,0 +1,36 @@
+# This plugin can be used for custom load balancing solutions.
+# It allows to set prefix and suffix for the used interface.
+
+import BroControl.plugin
+
+class LBCustom(BroControl.plugin.Plugin):
+    def __init__(self):
+        super(LBCustom, self).__init__(apiversion=1)
+
+    def name(self):
+        return "lb_custom"
+
+    def pluginVersion(self):
+        return 1
+
+    def init(self):
+        useplugin = False
+
+        for nn in self.nodes():
+            if nn.type != "worker" or nn.lb_method != "custom":
+                continue
+
+            useplugin = True
+
+            iface_prefix = self.getOption("InterfacePrefix")
+            iface_suffix = self.getOption("InterfaceSuffix")
+            nn.interface = "%s%s%s" % (iface_prefix, nn.interface, iface_suffix)
+
+        return useplugin
+
+    def options(self):
+          custom_options = [
+            ("InterfacePrefix", "string", "", "Prefix to prepend to the configured interface name."),
+            ("InterfaceSuffix", "string", "", "Suffix to append to the configured interface name."),
+          ]
+          return custom_options


### PR DESCRIPTION
The plugin introduces a new load balancing method ``custom``, which does nothing by default. To support packet source plugins, it allows configuration of a prefix and suffix for the interface name. For example add the following line to broctl.cfg to enable the AF_Packet plugin: ``lb_custom.InterfacePrefix = af_packet::``