### PR TITLE
Fix leaking resources from never closing out the Broccoli connection

### DIFF
--- a/BroControl/events.py
+++ b/BroControl/events.py
@@ -47,6 +47,7 @@ def send_events_parallel(events):
 
     for (node, result_event, bc) in sent:
         (success, result_args) = _send_event_wait(node, result_event, bc)
+        bc.connDelete()
         results += [(node, success, result_args)]
 
     return results


### PR DESCRIPTION
connDelete() is never called in broctl, which is generally not an issue if it is being used via the command line. However, given the Python interface for calling into broctl, if a service is written around broctl and any parallel events are sent (peerstatus, netstats, etc.) then a TCP connection will be maintained given a connDelete() is not called. After a fairly certain interval, resources become an issue and things fail.