### PR TITLE
Update control.py

### DIFF
--- a/BroControl/control.py
+++ b/BroControl/control.py
@@ -896,9 +896,9 @@ class Controller:
             netif = netif.split("@", 1)[0]
 
         elif "::" in netif:
-            # Interface name has packet source prefix (e.g. "af_packet::eth0"),
-            # so don't try to run capstats on this interface.
-            netif = None
+            # Strip the prefix so capstats actually works
+            # when a prefix is used.
+            netif = netif.split("::")[1]
 
         return netif
 


### PR DESCRIPTION
Fix capstats so it returns the actual interface name when using af_packet or netmap.