### PR TITLE
rsync: ignore existing files to preserve posix capabilities

### DIFF
--- a/BroControl/execute.py
+++ b/BroControl/execute.py
@@ -52,7 +52,7 @@ def sync(nodes, paths, cmdout):
     result = True
     cmds = []
     for n in nodes:
-        args = ['-rRl', '--delete', '--rsh="ssh -o BatchMode=yes -o LogLevel=error -o ConnectTimeout=30"']
+        args = ['-rRl', '--delete', '--ignore-existing', '--rsh="ssh -o BatchMode=yes -o LogLevel=error -o ConnectTimeout=30"']
         dst = ["%s:/" % util.format_rsync_addr(util.scope_addr(n.addr))]
         args += paths + dst
         cmdline = "rsync %s" % " ".join(args)


### PR DESCRIPTION
Running bro without superuser permissions might require `cap_net_raw+eip` capability set on bro binary. Unfortunately running `broctl install` will overwrite bro binary on every worker nodes and effectively remove capabilities (unless broctl/rsync invoked by root). 

This might not be the perfect solution but will avoid stripping the capability once it's set on worker node.