### PR TITLE
Fix capstats when using af_packet

### DIFF
--- a/BroControl/control.py
+++ b/BroControl/control.py
@@ -896,9 +896,9 @@ class Controller:
             netif = netif.split("@", 1)[0]
 
         elif "::" in netif:
-            # Interface name has packet source prefix (e.g. "af_packet::eth0"),
-            # so don't try to run capstats on this interface.
-            netif = None
+            # Strip the prefix so capstats actually works
+            # when a prefix is used.
+            netif = netif.split("::")[1]
 
         return netif
 

--- a/BroControl/control.py
+++ b/BroControl/control.py
@@ -896,9 +896,13 @@ class Controller:
             netif = netif.split("@", 1)[0]
 
         elif "::" in netif:
-            # Strip the prefix so capstats actually works
-            # when a prefix is used.
-            netif = netif.split("::")[1]
+            # Check to see if it is af_packet since we know it works
+            # Otherwise disable it since we know netmap etc is broken.
+            
+            if "af_packet" in netif:
+                netif = netif.split("::")[1]
+            else
+                netif = None
 
         return netif
 

--- a/BroControl/control.py
+++ b/BroControl/control.py
@@ -901,7 +901,7 @@ class Controller:
             
             if "af_packet" in netif:
                 netif = netif.split("::")[1]
-            else
+            else:
                 netif = None
 
         return netif


### PR DESCRIPTION
I know this was dropped last time because it didn't take in account for netmap etc. This time it is specific to af_packet and makes sure it only changes if it is af_packet. I know this is going away but since you all are going to be busy renaming everything it would be nice to get this in so all of us who use af_packet don't have to keep modifying after every upgrade.