### PR TITLE
Modify check-pid for Alpine support

### DIFF
--- a/bin/helpers/check-pid
+++ b/bin/helpers/check-pid
@@ -4,10 +4,4 @@
 #
 #  check-pid <pid>
 
-ps -p $1 -o args | grep -q bro
-
-if [ $? -eq 0 ]; then
-    echo "running"
-else
-    echo "not running"
-fi
+(kill -0 $1 >/dev/null 2>&1 && pgrep bro | grep -q $1) && echo "running" || echo "not running"


### PR DESCRIPTION
The version of ps that ships with Alpine doesn't have a -p option.
This means that broctl marks all bro processes as crashed. kill
appears to be a more Alpine friendly solution.